### PR TITLE
Getting rid of global variables && other improvements

### DIFF
--- a/include/ccl/handler/cmd_handler.hpp
+++ b/include/ccl/handler/cmd_handler.hpp
@@ -19,10 +19,7 @@ namespace ccl::handler
 
         Cmd() noexcept = default;
 
-        [[nodiscard]] static auto instance() -> Cmd &
-        {
-            return defaultCmdHandler;
-        }
+        [[nodiscard]] static auto instance() -> Cmd &;
 
     private:
         auto onHandle(const ExceptionT *error) -> void final;
@@ -33,6 +30,8 @@ namespace ccl::handler
 
     class Cmd::CmdFormatter
     {
+        friend class Cmd;
+
         std::string formattingBuffer{};
         string_view workingLine{};
         string_view filename{};
@@ -45,10 +44,10 @@ namespace ccl::handler
     public:
         explicit CmdFormatter(const ExceptionT *exception) noexcept;
 
+    private:
         template<fmt::color Color, typename HandleType>
         [[nodiscard]] auto format(HandleType &&handle_type) -> std::string;
 
-    private:
         auto formatFilename() -> void;
 
         template<fmt::color Color, typename HandleType>

--- a/include/ccl/handler/exception_handler.hpp
+++ b/include/ccl/handler/exception_handler.hpp
@@ -31,10 +31,7 @@ namespace ccl
         auto operator=(ExceptionHandler &&) -> void = delete;
         auto operator=(const ExceptionHandler &) -> void = delete;
 
-        [[nodiscard]] static auto instance() -> ExceptionHandler &
-        {
-            return defaultExceptionHandler;
-        }
+        [[nodiscard]] static auto instance() -> ExceptionHandler &;
 
         auto handle(const ExceptionT *error) -> void;
 

--- a/programs/ccll.cpp
+++ b/programs/ccll.cpp
@@ -7,16 +7,26 @@
 
 namespace po = boost::program_options;
 
+std::string SourceFile;
+std::string HeaderFile;
+
+auto getOptionDescription() -> po::options_description
+{
+    po::options_description desc("Allowed options");
+
+    desc.add_options()("help,h", "produce help message");
+
+    desc.add_options()(
+        "lexical-analyzer-rules,l", po::value(&SourceFile), "file with rules for lexical analyzer");
+
+    desc.add_options()("output,o", po::value(&HeaderFile), "output header name");
+
+    return desc;
+}
+
 auto main(int argc, char *argv[]) -> int
 {
-    std::string source_file;
-    std::string header_name;
-
-    po::options_description desc("Allowed options");
-    desc.add_options()("help,h", "produce help message")(
-        "lexical-analyzer-rules,l", po::value(&source_file),
-        "file with rules for lexical analyzer")(
-        "output,o", po::value(&header_name), "output header name");
+    auto desc = getOptionDescription();
 
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
@@ -34,13 +44,13 @@ auto main(int argc, char *argv[]) -> int
         return 1;
     }
 
-    auto generated_header = ccl::lex::AnalyzerGenerator::generateStaticVersion(source_file);
+    auto generated_header = ccl::lex::AnalyzerGenerator::generateStaticVersion(SourceFile);
 
     auto file_stream = std::fstream{};
-    file_stream.open(header_name, std::ios::out);
+    file_stream.open(HeaderFile, std::ios::out);
 
     if (!file_stream.is_open()) {
-        fmt::print("Error: cannot open file {}\n", header_name);
+        fmt::print("Error: cannot open file {}\n", HeaderFile);
         return 1;
     }
 

--- a/src/ccl/handler/cmd_handler.cpp
+++ b/src/ccl/handler/cmd_handler.cpp
@@ -2,7 +2,12 @@
 
 namespace ccl::handler
 {
-    Cmd Cmd::defaultCmdHandler;
+    auto Cmd::instance() -> Cmd &
+    {
+        static auto default_instance = Cmd{};
+
+        return default_instance;
+    }
 
     Cmd::CmdFormatter::CmdFormatter(const ExceptionT *exception) noexcept
       : workingLine{exception->getWorkingLine()}

--- a/src/ccl/handler/exception_handler.cpp
+++ b/src/ccl/handler/exception_handler.cpp
@@ -4,7 +4,12 @@
 
 namespace ccl
 {
-    ExceptionHandler ExceptionHandler::defaultExceptionHandler;// NOLINT
+    auto ExceptionHandler::instance() -> ExceptionHandler &
+    {
+        static auto default_instance = ExceptionHandler{};
+
+        return default_instance;
+    }
 
     // NOLINTNEXTLINE
     auto ExceptionHandler::handle(const ExceptionT *const error) -> void


### PR DESCRIPTION
1) Getting rid of global variables
2) Cmd::CmdFormatter::format must be private
3) Improvements in ccll source file